### PR TITLE
Feature search threads by title and content

### DIFF
--- a/apps/application/convex/agent/threads.ts
+++ b/apps/application/convex/agent/threads.ts
@@ -1,6 +1,13 @@
 import { components } from "../_generated/api";
 import { v } from "convex/values";
-import { action, ActionCtx, mutation, MutationCtx, query, QueryCtx } from "../_generated/server";
+import {
+  action,
+  ActionCtx,
+  mutation,
+  MutationCtx,
+  query,
+  QueryCtx,
+} from "../_generated/server";
 import { getThreadMetadata, vMessage } from "@convex-dev/agent";
 import { checkCaseAccess, getCurrentUserFromAuth } from "../auth_utils";
 import { agent } from "./agent";
@@ -9,7 +16,7 @@ import { paginationOptsValidator } from "convex/server";
 
 /**
  * Authorizes access to a thread based on user identity and thread ownership.
- * 
+ *
  * @param ctx - The Convex context (QueryCtx, MutationCtx, or ActionCtx)
  * @param threadId - The ID of the thread to authorize access to
  * @param requireUser - Optional flag to require a valid user identity
@@ -17,28 +24,31 @@ import { paginationOptsValidator } from "convex/server";
  * @throws {Error} When user does not have access to the thread (commented out)
  */
 export async function authorizeThreadAccess(
-    ctx: QueryCtx | MutationCtx | ActionCtx,
-    threadId: string,
-    requireUser?: boolean,
+  ctx: QueryCtx | MutationCtx | ActionCtx,
+  threadId: string,
+  requireUser?: boolean,
 ) {
-    const user = await ctx.auth.getUserIdentity();
-    const userId = user?.subject;
+  const user = await ctx.auth.getUserIdentity();
+  const userId = user?.subject;
 
-    if (requireUser && !userId){
-        throw new Error("Unauthorized: user is required");
-
-    }
-    const {userId: threadUserId } = await getThreadMetadata(ctx, components.agent, {threadId});
-    // if (requireUser && threadUserId !== userId) {
-    //     throw new Error("Unauthorized: user does not match user thread")
-    // }
+  if (requireUser && !userId) {
+    throw new Error("Unauthorized: user is required");
+  }
+  const { userId: threadUserId } = await getThreadMetadata(
+    ctx,
+    components.agent,
+    { threadId },
+  );
+  // if (requireUser && threadUserId !== userId) {
+  //     throw new Error("Unauthorized: user does not match user thread")
+  // }
 }
 
 /**
  * Lists threads for a user, optionally filtered by case.
- * 
+ *
  * TODO: Have this load all threads from all users in the case with metadata
- * 
+ *
  * @param paginationOpts - Pagination options for the query
  * @param caseId - Optional case ID to filter threads by case
  * @returns Promise resolving to a list of threads with pagination
@@ -52,17 +62,17 @@ export const listThreads = query({
   handler: async (ctx, args) => {
     const userId = await getCurrentUserFromAuth(ctx);
     if (args.caseId) {
-        const access = await checkCaseAccess(ctx, args.caseId, userId._id);
-        if (!access.hasAccess) {
-            throw new Error("Unauthorized: No access to this case");
-        }
+      const access = await checkCaseAccess(ctx, args.caseId, userId._id);
+      if (!access.hasAccess) {
+        throw new Error("Unauthorized: No access to this case");
+      }
     }
 
     let threadUserId: string;
     if (args.caseId) {
-        threadUserId = `case:${args.caseId}_${userId._id}`;
+      threadUserId = `case:${args.caseId}_${userId._id}`;
     } else {
-        threadUserId = `user:${userId._id}`;
+      threadUserId = `user:${userId._id}`;
     }
 
     const threads = await ctx.runQuery(
@@ -74,8 +84,65 @@ export const listThreads = query({
 });
 
 /**
+ * Searches threads by title for a user, optionally filtered by case.
+ *
+ * @param searchTerm - The search term to filter threads by title
+ * @param caseId - Optional case ID to filter threads by case
+ * @returns Promise resolving to a list of threads matching the search term
+ * @throws {Error} When user doesn't have access to the specified case
+ */
+export const searchThreads = query({
+  args: {
+    searchTerm: v.string(),
+    caseId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getCurrentUserFromAuth(ctx);
+    if (args.caseId) {
+      const access = await checkCaseAccess(ctx, args.caseId, userId._id);
+      if (!access.hasAccess) {
+        throw new Error("Unauthorized: No access to this case");
+      }
+    }
+
+    let threadUserId: string;
+    if (args.caseId) {
+      threadUserId = `case:${args.caseId}_${userId._id}`;
+    } else {
+      threadUserId = `user:${userId._id}`;
+    }
+
+    // Get all threads for the user (we'll filter by search term)
+    const allThreads = await ctx.runQuery(
+      components.agent.threads.listThreadsByUserId,
+      {
+        userId: threadUserId,
+        paginationOpts: { numItems: 100, cursor: null as any },
+      },
+    );
+
+    // Filter threads by search term in title
+    const searchTermLower = args.searchTerm.toLowerCase().trim();
+    if (!searchTermLower) {
+      return allThreads;
+    }
+
+    const filteredThreads = {
+      ...allThreads,
+      page: allThreads.page.filter((thread) =>
+        (thread.title || "Untitled Thread")
+          .toLowerCase()
+          .includes(searchTermLower),
+      ),
+    };
+
+    return filteredThreads;
+  },
+});
+
+/**
  * Creates a new thread for a user, optionally associated with a case.
- * 
+ *
  * @param title - Optional title for the new thread
  * @param initialMessage - Optional initial message to add to the thread
  * @param caseId - Optional case ID to associate the thread with
@@ -83,64 +150,66 @@ export const listThreads = query({
  * @throws {Error} When user doesn't have access to the specified case
  */
 export const createNewThread = mutation({
-    args: {
-        title: v.optional(v.string()),
-        initialMessage: v.optional(vMessage),
-        caseId: v.optional(v.string()),
-    },
-    handler: async (ctx, args) => {
-        const userId = await getCurrentUserFromAuth(ctx);
+  args: {
+    title: v.optional(v.string()),
+    initialMessage: v.optional(vMessage),
+    caseId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getCurrentUserFromAuth(ctx);
 
-        if (args.caseId) {
-            const access = await checkCaseAccess(ctx, args.caseId, userId._id);
-            if (!access.hasAccess) {
-                throw new Error("Unauthorized: No access to this case");
-            }
-        }
+    if (args.caseId) {
+      const access = await checkCaseAccess(ctx, args.caseId, userId._id);
+      if (!access.hasAccess) {
+        throw new Error("Unauthorized: No access to this case");
+      }
+    }
 
-        let threadUserId: string;
-        if (args.caseId) {
-            threadUserId = `case:${args.caseId}_${userId._id}`;
-        } else {
-            threadUserId = `user:${userId._id}`;
-        }
+    let threadUserId: string;
+    if (args.caseId) {
+      threadUserId = `case:${args.caseId}_${userId._id}`;
+    } else {
+      threadUserId = `user:${userId._id}`;
+    }
 
-        const { threadId } = await agent.createThread(ctx, {
-            userId: threadUserId,
-            title: args.title,
-        });        
+    const { threadId } = await agent.createThread(ctx, {
+      userId: threadUserId,
+      title: args.title,
+    });
 
-       if (args.initialMessage) {
-        await agent.saveMessage(ctx, {
-            threadId,
-            message: args.initialMessage,
-        });
-       }
-       return threadId;
-    },
+    if (args.initialMessage) {
+      await agent.saveMessage(ctx, {
+        threadId,
+        message: args.initialMessage,
+      });
+    }
+    return threadId;
+  },
 });
 
 /**
  * Retrieves the title and summary metadata for a specific thread.
- * 
+ *
  * @param threadId - The ID of the thread to get details for
  * @returns Promise resolving to an object containing title and summary
  * @throws {Error} When user doesn't have access to the thread
  */
 export const getThreadDetails = query({
-    args: {threadId: v.string()},
-    handler: async (ctx , {threadId}) => {
-        await authorizeThreadAccess(ctx, threadId);
-        const {title, summary} = await getThreadMetadata(ctx, components.agent, {threadId});
-        return {title, summary};
-    }
-})
+  args: { threadId: v.string() },
+  handler: async (ctx, { threadId }) => {
+    await authorizeThreadAccess(ctx, threadId);
+    const { title, summary } = await getThreadMetadata(ctx, components.agent, {
+      threadId,
+    });
+    return { title, summary };
+  },
+});
 
 /**
  * Updates the title and summary of a thread using AI generation.
- * 
+ *
  * NOTE: This function is currently commented out and not in use.
- * 
+ *
  * @param threadId - The ID of the thread to update
  * @throws {Error} When user doesn't have access to the thread
  */
@@ -166,4 +235,3 @@ export const getThreadDetails = query({
 //       await thread.updateMetadata({ title, summary });
 //     },
 //   });
-

--- a/apps/application/package.json
+++ b/apps/application/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@tiptap/core": "^3.2.1",
     "@tiptap/pm": "^3.2.1",
+    "@uidotdev/usehooks": "^2.4.1",
     "ai": "^5.0.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/application/src/components/Cases/CaseSideBar.tsx
+++ b/apps/application/src/components/Cases/CaseSideBar.tsx
@@ -44,6 +44,7 @@ import { usePermissionAwareNavigation } from "@/hooks/usePermissionAwareNavigati
 import { PERMISSIONS } from "@/permissions/types";
 import { IfCan } from "@/components/Permissions";
 import { useHighlight } from "@/context/HighlightContext";
+import { Suspense } from "react";
 
 export default function CaseSidebar() {
   const {
@@ -72,7 +73,6 @@ export default function CaseSidebar() {
   const [isCreatingRootFolder, setIsCreatingRootFolder] = useState(false);
   const [newRootFolderName, setNewRootFolderName] = useState("");
   const rootInputRef = useRef<HTMLInputElement | null>(null);
-  const [threadSearch, setThreadSearch] = useState("");
 
   const basePath = `/caso/${id}`;
 
@@ -399,15 +399,15 @@ export default function CaseSidebar() {
               className="flex flex-col gap-2 pl-2 pr-2 text-[12px] pt-1 overflow-y-auto max-h-40"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="px-1 pb-1">
-                <Input
-                  placeholder="Buscar threads por título..."
-                  value={threadSearch}
-                  onChange={(e) => setThreadSearch(e.target.value)}
-                  className="h-5 text-xs placeholder:text-xs"
-                />
-              </div>
-              <AIAgentThreadSelector searchTerm={threadSearch} />
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center py-4">
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>
+                  </div>
+                }
+              >
+                <AIAgentThreadSelector />
+              </Suspense>
             </CollapsibleContent>
           </Collapsible>
         </div>

--- a/apps/application/src/components/Cases/CaseSideBar.tsx
+++ b/apps/application/src/components/Cases/CaseSideBar.tsx
@@ -404,7 +404,7 @@ export default function CaseSidebar() {
                   placeholder="Buscar threads por título..."
                   value={threadSearch}
                   onChange={(e) => setThreadSearch(e.target.value)}
-                  className="h-7 text-xs"
+                  className="h-5 text-xs placeholder:text-xs"
                 />
               </div>
               <AIAgentThreadSelector searchTerm={threadSearch} />

--- a/apps/application/src/components/Cases/CaseSideBar.tsx
+++ b/apps/application/src/components/Cases/CaseSideBar.tsx
@@ -72,6 +72,7 @@ export default function CaseSidebar() {
   const [isCreatingRootFolder, setIsCreatingRootFolder] = useState(false);
   const [newRootFolderName, setNewRootFolderName] = useState("");
   const rootInputRef = useRef<HTMLInputElement | null>(null);
+  const [threadSearch, setThreadSearch] = useState("");
 
   const basePath = `/caso/${id}`;
 
@@ -395,10 +396,18 @@ export default function CaseSidebar() {
               />
             </CollapsibleTrigger>
             <CollapsibleContent
-              className="flex flex-col gap-1 pl-2 text-[12px] pt-1 overflow-y-auto max-h-40"
+              className="flex flex-col gap-2 pl-2 pr-2 text-[12px] pt-1 overflow-y-auto max-h-40"
               onClick={(e) => e.stopPropagation()}
             >
-              <AIAgentThreadSelector />
+              <div className="px-1 pb-1">
+                <Input
+                  placeholder="Buscar threads por título..."
+                  value={threadSearch}
+                  onChange={(e) => setThreadSearch(e.target.value)}
+                  className="h-7 text-xs"
+                />
+              </div>
+              <AIAgentThreadSelector searchTerm={threadSearch} />
             </CollapsibleContent>
           </Collapsible>
         </div>

--- a/apps/application/src/components/Cases/CaseThreadSelector.tsx
+++ b/apps/application/src/components/Cases/CaseThreadSelector.tsx
@@ -4,6 +4,7 @@ import { useThread } from "@/context/ThreadContext";
 import { useCase } from "@/context/CaseContext";
 import { Input } from "@/components/ui/input";
 import { useState } from "react";
+import { useDebounce } from "@uidotdev/usehooks";
 
 // Extend the thread type to include search properties
 type ThreadWithSearch = {
@@ -46,15 +47,16 @@ export function AIAgentThreadSelector() {
   const { threadId, setThreadId } = useThread();
   const { caseId } = useCase();
   const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
-  const hasSearchTerm = searchTerm.trim().length > 0;
+  const hasSearchTerm = debouncedSearchTerm.trim().length > 0;
 
   // Use search function when there's a search term, otherwise use regular list
   const searchResults = useQuery(
     api.agent.threads.searchThreads,
     hasSearchTerm
       ? {
-          searchTerm: searchTerm.trim(),
+          searchTerm: debouncedSearchTerm.trim(),
           caseId: caseId || undefined,
         }
       : "skip",
@@ -80,6 +82,15 @@ export function AIAgentThreadSelector() {
 
   return (
     <div className="flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
+      <div className="px-1 pb-1">
+        <Input
+          placeholder="Buscar threads por título..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="h-5 text-xs placeholder:text-xs"
+          disabled={isLoading}
+        />
+      </div>
       {isLoading && (
         <div className="flex items-center justify-center py-4">
           <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>
@@ -88,19 +99,10 @@ export function AIAgentThreadSelector() {
 
       {!isLoading && (
         <>
-          <div className="px-1 pb-1">
-            <Input
-              placeholder="Buscar threads por título..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="h-5 text-xs placeholder:text-xs"
-            />
-          </div>
-
           <div className="flex flex-col">
             {hasSearchTerm && items.length === 0 && (
               <div className="px-3 py-2.5 text-muted-foreground text-xs">
-                No hay threads que contengan "{searchTerm}"
+                No hay threads que contengan "{debouncedSearchTerm}"
               </div>
             )}
 
@@ -147,7 +149,7 @@ export function AIAgentThreadSelector() {
                         <div className="text-xs text-foreground/70 leading-relaxed line-clamp-3">
                           {highlightSearchTerm(
                             thread.searchSnippet,
-                            searchTerm.trim(),
+                            debouncedSearchTerm.trim(),
                           )}
                         </div>
                       </div>

--- a/apps/application/src/components/Cases/CaseThreadSelector.tsx
+++ b/apps/application/src/components/Cases/CaseThreadSelector.tsx
@@ -3,6 +3,43 @@ import { useQuery } from "convex/react";
 import { useThread } from "@/context/ThreadContext";
 import { useCase } from "@/context/CaseContext";
 
+// Extend the thread type to include search properties
+type ThreadWithSearch = {
+  _creationTime: number;
+  _id: string;
+  status: "active" | "archived";
+  summary?: string | undefined;
+  title?: string | undefined;
+  userId?: string | undefined;
+  searchSnippet?: string;
+  matchType?: "title" | "content";
+};
+
+// Function to highlight search term in text
+const highlightSearchTerm = (text: string, searchTerm: string) => {
+  if (!searchTerm.trim()) return text;
+
+  const regex = new RegExp(
+    `(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+    "gi",
+  );
+  const parts = text.split(regex);
+
+  return parts.map((part, index) => {
+    if (part.toLowerCase() === searchTerm.toLowerCase()) {
+      return (
+        <mark
+          key={index}
+          className="bg-yellow-200 text-yellow-900 px-0.5 rounded"
+        >
+          {part}
+        </mark>
+      );
+    }
+    return part;
+  });
+};
+
 export function AIAgentThreadSelector({
   searchTerm = "",
 }: {
@@ -35,16 +72,15 @@ export function AIAgentThreadSelector({
   );
 
   const threads = hasSearchTerm ? searchResults : listResults;
-  const items = threads?.page ?? [];
+  const items = (threads?.page ?? []) as ThreadWithSearch[];
 
   return (
     <div className="flex flex-col" onClick={(e) => e.stopPropagation()}>
       {/* Thread List */}
       <div className="flex flex-col">
-        {items.length === 0 && (
-          <div className="px-3 py-2.5 cursor-pointer transition-colors border-b border-border/20 last:border-b-0">
-            No tenes historial de chat con ({searchTerm}) / Proba con otro
-            termino
+        {items.length === 0 && hasSearchTerm && (
+          <div className="px-3 py-2.5 text-muted-foreground text-xs">
+            No hay threads que contengan "{searchTerm}"
           </div>
         )}
         {items.map((thread) => (
@@ -60,18 +96,41 @@ export function AIAgentThreadSelector({
               setThreadId(thread._id);
             }}
           >
-            <div className="flex items-center justify-between">
-              <span
-                className={`
-                  text-sm font-medium truncate
-                  ${thread._id === threadId ? "text-foreground" : "text-foreground/80"}
-                `}
-              >
-                {thread.title || "Untitled Thread"}
-              </span>
-              <span className="text-xs text-muted-foreground ml-2 shrink-0">
-                {new Date(thread._creationTime).toLocaleDateString()}
-              </span>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span
+                  className={`
+                    text-sm font-medium truncate
+                    ${thread._id === threadId ? "text-foreground" : "text-foreground/80"}
+                  `}
+                >
+                  {thread.title || "Untitled Thread"}
+                </span>
+                <span className="text-xs text-muted-foreground ml-2 shrink-0">
+                  {new Date(thread._creationTime).toLocaleDateString()}
+                </span>
+              </div>
+
+              {/* Show snippet only when searching and there's a content match */}
+              {hasSearchTerm &&
+                thread.searchSnippet &&
+                thread.matchType === "content" && (
+                  <div className="bg-accent/30 rounded-md px-3 py-2 border-l-2 border-primary/40">
+                    <div className="flex items-center gap-2 mb-1">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          Contenido
+                        </span>
+                      </div>
+                    </div>
+                    <div className="text-xs text-foreground/70 leading-relaxed line-clamp-3">
+                      {highlightSearchTerm(
+                        thread.searchSnippet,
+                        searchTerm.trim(),
+                      )}
+                    </div>
+                  </div>
+                )}
             </div>
           </div>
         ))}

--- a/apps/application/src/components/Cases/CaseThreadSelector.tsx
+++ b/apps/application/src/components/Cases/CaseThreadSelector.tsx
@@ -2,6 +2,8 @@ import { api } from "../../../convex/_generated/api";
 import { useQuery } from "convex/react";
 import { useThread } from "@/context/ThreadContext";
 import { useCase } from "@/context/CaseContext";
+import { Input } from "@/components/ui/input";
+import { useState } from "react";
 
 // Extend the thread type to include search properties
 type ThreadWithSearch = {
@@ -40,13 +42,10 @@ const highlightSearchTerm = (text: string, searchTerm: string) => {
   });
 };
 
-export function AIAgentThreadSelector({
-  searchTerm = "",
-}: {
-  searchTerm?: string;
-}) {
+export function AIAgentThreadSelector() {
   const { threadId, setThreadId } = useThread();
   const { caseId } = useCase();
+  const [searchTerm, setSearchTerm] = useState("");
 
   const hasSearchTerm = searchTerm.trim().length > 0;
 
@@ -74,67 +73,91 @@ export function AIAgentThreadSelector({
   const threads = hasSearchTerm ? searchResults : listResults;
   const items = (threads?.page ?? []) as ThreadWithSearch[];
 
-  return (
-    <div className="flex flex-col" onClick={(e) => e.stopPropagation()}>
-      {/* Thread List */}
-      <div className="flex flex-col">
-        {items.length === 0 && hasSearchTerm && (
-          <div className="px-3 py-2.5 text-muted-foreground text-xs">
-            No hay threads que contengan "{searchTerm}"
-          </div>
-        )}
-        {items.map((thread) => (
-          <div
-            key={thread._id}
-            className={`
-              px-3 py-2.5 cursor-pointer transition-colors border-b border-border/20 last:border-b-0
-              hover:bg-accent/50
-              ${thread._id === threadId ? "bg-accent" : ""}
-            `}
-            onClick={(e) => {
-              e.stopPropagation();
-              setThreadId(thread._id);
-            }}
-          >
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <span
-                  className={`
-                    text-sm font-medium truncate
-                    ${thread._id === threadId ? "text-foreground" : "text-foreground/80"}
-                  `}
-                >
-                  {thread.title || "Untitled Thread"}
-                </span>
-                <span className="text-xs text-muted-foreground ml-2 shrink-0">
-                  {new Date(thread._creationTime).toLocaleDateString()}
-                </span>
-              </div>
+  // Loading states
+  const isSearchLoading = hasSearchTerm && searchResults === undefined;
+  const isListLoading = !hasSearchTerm && listResults === undefined;
+  const isLoading = isSearchLoading || isListLoading;
 
-              {/* Show snippet only when searching and there's a content match */}
-              {hasSearchTerm &&
-                thread.searchSnippet &&
-                thread.matchType === "content" && (
-                  <div className="bg-accent/30 rounded-md px-3 py-2 border-l-2 border-primary/40">
-                    <div className="flex items-center gap-2 mb-1">
-                      <div className="flex items-center gap-1.5">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          Contenido
-                        </span>
-                      </div>
-                    </div>
-                    <div className="text-xs text-foreground/70 leading-relaxed line-clamp-3">
-                      {highlightSearchTerm(
-                        thread.searchSnippet,
-                        searchTerm.trim(),
-                      )}
-                    </div>
-                  </div>
-                )}
-            </div>
+  return (
+    <div className="flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
+      {isLoading && (
+        <div className="flex items-center justify-center py-4">
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>
+        </div>
+      )}
+
+      {!isLoading && (
+        <>
+          <div className="px-1 pb-1">
+            <Input
+              placeholder="Buscar threads por título..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="h-5 text-xs placeholder:text-xs"
+            />
           </div>
-        ))}
-      </div>
+
+          <div className="flex flex-col">
+            {hasSearchTerm && items.length === 0 && (
+              <div className="px-3 py-2.5 text-muted-foreground text-xs">
+                No hay threads que contengan "{searchTerm}"
+              </div>
+            )}
+
+            {items.map((thread) => (
+              <div
+                key={thread._id}
+                className={`
+                px-3 py-2.5 cursor-pointer transition-colors border-b border-border/20 last:border-b-0
+                hover:bg-accent/50
+                ${thread._id === threadId ? "bg-accent" : ""}
+              `}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setThreadId(thread._id);
+                }}
+              >
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span
+                      className={`
+                      text-sm font-medium truncate
+                      ${thread._id === threadId ? "text-foreground" : "text-foreground/80"}
+                    `}
+                    >
+                      {thread.title || "Untitled Thread"}
+                    </span>
+                    <span className="text-xs text-muted-foreground ml-2 shrink-0">
+                      {new Date(thread._creationTime).toLocaleDateString()}
+                    </span>
+                  </div>
+
+                  {/* Show snippet only when searching and there's a content match */}
+                  {hasSearchTerm &&
+                    thread.searchSnippet &&
+                    thread.matchType === "content" && (
+                      <div className="bg-accent/30 rounded-md px-3 py-2 border-l-2 border-primary/40">
+                        <div className="flex items-center gap-2 mb-1">
+                          <div className="flex items-center gap-1.5">
+                            <span className="text-xs font-medium text-muted-foreground">
+                              Contenido
+                            </span>
+                          </div>
+                        </div>
+                        <div className="text-xs text-foreground/70 leading-relaxed line-clamp-3">
+                          {highlightSearchTerm(
+                            thread.searchSnippet,
+                            searchTerm.trim(),
+                          )}
+                        </div>
+                      </div>
+                    )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/application/src/components/Cases/CaseThreadSelector.tsx
+++ b/apps/application/src/components/Cases/CaseThreadSelector.tsx
@@ -1,22 +1,36 @@
 import { api } from "../../../convex/_generated/api";
-import { useQuery } from "convex/react"
+import { useQuery } from "convex/react";
 import { useThread } from "@/context/ThreadContext";
 import { useCase } from "@/context/CaseContext";
+import { useMemo } from "react";
 
-export function AIAgentThreadSelector() {
+export function AIAgentThreadSelector({
+  searchTerm = "",
+}: {
+  searchTerm?: string;
+}) {
   const { threadId, setThreadId } = useThread();
   const { caseId } = useCase();
   // Get threads from Convex agent (not the old chat system)
-  const threads = useQuery(api.agent.threads.listThreads, { 
+  const threads = useQuery(api.agent.threads.listThreads, {
     paginationOpts: { numItems: 50, cursor: null as any },
-    caseId: caseId || undefined
+    caseId: caseId || undefined,
   });
+
+  const items = threads?.page ?? [];
+  const filteredThreads = useMemo(() => {
+    const q = (searchTerm ?? "").trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((thread) =>
+      (thread.title || "Untitled Thread").toLowerCase().includes(q),
+    );
+  }, [items, searchTerm]);
 
   return (
     <div className="flex flex-col" onClick={(e) => e.stopPropagation()}>
       {/* Thread List */}
       <div className="flex flex-col">
-        {threads?.page?.map((thread) => (
+        {filteredThreads.map((thread) => (
           <div
             key={thread._id}
             className={`
@@ -46,5 +60,5 @@ export function AIAgentThreadSelector() {
         ))}
       </div>
     </div>
-  )
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@tiptap/pm':
         specifier: ^3.2.1
         version: 3.2.2
+      '@uidotdev/usehooks':
+        specifier: ^2.4.1
+        version: 2.4.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       ai:
         specifier: ^5.0.20
         version: 5.0.22(zod@3.25.76)
@@ -2453,6 +2456,13 @@ packages:
   '@typescript-eslint/visitor-keys@8.42.0':
     resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@uidotdev/usehooks@2.4.1':
+    resolution: {integrity: sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -7899,6 +7909,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.42.0
       eslint-visitor-keys: 4.2.1
+
+  '@uidotdev/usehooks@2.4.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
# feat(search): Buscador de threads por **título** y **contenido**

## Qué vamos a hacer
Implementar búsqueda que incluya el **contenido de la conversación** (mensajes) además del **título** del thread.  
La idea es unificar resultados y ordenar por relevancia, mostrando opcionalmente un snippet.

## Lo que ya tenemos (hecho)
- `searchThreads` que filtra **por título** (con control de acceso a `caseId` y `threadUserId`).
- Listado/paginación básica vía `listThreadsByUserId`.

## Lo que falta (a implementar)
- **Índice de búsqueda** en `messages.content` (Convex) filtrado por `threadUserId`.
- **Denormalizar** `threadUserId` en `messages` (si no existe) + migración/backfill.
- **Nueva query** de búsqueda por contenido (o unificada):
  - Filtra por `threadUserId` (y `caseId` si aplica).
  - Devuelve `threadId`, `score`, `matchType` (`content`/`both`) y **snippets**.
  - Ordena por relevancia y `updatedAt`.
- **Tests**: unitarios de acceso y de ranking básico.
- **UI**: mostrar snippet y badge de origen del match (título/contenido).

