### PR TITLE
Real-time diff review for editor tools

### DIFF
--- a/apps/application/src/components/Editor/EscritoToolsTester.tsx
+++ b/apps/application/src/components/Editor/EscritoToolsTester.tsx
@@ -45,7 +45,7 @@ interface EditOperation {
 
 
 export function EscritoToolsTester() {
-  const { escritoId } = useEscrito();
+  const { escritoId, editor } = useEscrito();
   const [operations, setOperations] = useState<EditOperation[]>([]);
   const [currentOperation, setCurrentOperation] = useState<Partial<EditOperation>>({
     type: 'replace'
@@ -137,6 +137,13 @@ export function EscritoToolsTester() {
         }
       });
 
+      // Open a Change Review group for this batch (if editor present)
+      const groupId = `tools:${Date.now()}`;
+      if (editor) {
+        editor.commands.startReview();
+        editor.commands.setChangeReviewGroup({ id: groupId, label: 'Tools Tester', source: 'tool' });
+      }
+
       // Convert operations to the format expected by the mutation (remove id field)
       const editsForMutation = operations.map(({ id, ...edit }) => edit);
       
@@ -149,6 +156,11 @@ export function EscritoToolsTester() {
 
       addLog(`Successfully applied operations!`, 'success');
       addLog(`Mutation result: ${JSON.stringify(result, null, 2)}`);
+
+      // Close active group tagging after mutation
+      if (editor) {
+        editor.commands.setChangeReviewGroup(null);
+      }
 
       // Clear operations after successful application
       setOperations([]);

--- a/apps/application/src/components/Editor/editor-styles.css
+++ b/apps/application/src/components/Editor/editor-styles.css
@@ -238,6 +238,13 @@
   line-height: 1.4;
 }
 
+/* Change Review inline inserted highlight */
+.cr-inserted {
+  background-color: rgba(16, 185, 129, 0.25);
+  text-decoration: underline;
+  text-decoration-color: rgba(16, 185, 129, 0.9);
+}
+
 /* Block change nodes should display as block but keep same button styling */
 [data-semantic-type="block_change"] {
   display: block !important;

--- a/apps/application/src/components/Editor/extensions/changeReview.ts
+++ b/apps/application/src/components/Editor/extensions/changeReview.ts
@@ -1,0 +1,292 @@
+import { Extension } from "@tiptap/core";
+import type { Editor as TiptapEditor } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { Transaction, EditorState } from "@tiptap/pm/state";
+import { createJsonDiff } from "../../../../../packages/shared/src/diff/jsonDiff";
+
+type ReviewMode = "alwaysDiff" | "disabled";
+
+export type ChangeReviewGroup = {
+  id: string;
+  label: string;
+  source: "tool" | "user";
+  createdAt: number;
+  patches: Array<Patch>;
+  visible: boolean;
+};
+
+export type Patch = {
+  prevDocHash?: string;
+  nextDocHash?: string;
+  diff: unknown;
+  ranges: Array<{ from: number; to: number }>;
+  transactionId: string;
+};
+
+type Baseline = {
+  snapshot: any;
+  createdAt: number;
+} | null;
+
+type ChangeReviewStorage = {
+  mode: ReviewMode;
+  baseline: Baseline;
+  groups: Record<string, ChangeReviewGroup>;
+  activeGroupId: string | null;
+};
+
+const pluginKey = new PluginKey<{
+  decorationSet: DecorationSet;
+  storage: ChangeReviewStorage;
+}>("changeReviewPlugin");
+
+function getOrCreateGroup(storage: ChangeReviewStorage, id: string, label?: string, source: "tool" | "user" = "user"): ChangeReviewGroup {
+  if (!storage.groups[id]) {
+    storage.groups[id] = {
+      id,
+      label: label ?? id,
+      source,
+      createdAt: Date.now(),
+      patches: [],
+      visible: true,
+    };
+  }
+  return storage.groups[id];
+}
+
+function collectInsertedRanges(tr: Transaction): Array<{ from: number; to: number }> {
+  const ranges: Array<{ from: number; to: number }> = [];
+  const mapping = tr.mapping;
+  for (let i = 0; i < mapping.maps.length; i++) {
+    const map = mapping.maps[i];
+    map.forEach((
+      _oldStart: number,
+      _oldEnd: number,
+      newStart: number,
+      newEnd: number,
+    ) => {
+      if (newEnd > newStart) {
+        ranges.push({ from: newStart, to: newEnd });
+      }
+    });
+  }
+  return ranges;
+}
+
+export const ChangeReviewExtension = Extension.create<{ reviewOptions?: { mode?: ReviewMode } }>({
+  name: "changeReview",
+
+  addStorage(): ChangeReviewStorage {
+    return {
+      mode: (this.options?.reviewOptions?.mode ?? "alwaysDiff") as ReviewMode,
+      baseline: null,
+      groups: {},
+      activeGroupId: null,
+    };
+  },
+
+  addCommands() {
+    return {
+      startReview:
+        (options?: { resetBaseline?: boolean }) =>
+        ({ editor }: { editor: TiptapEditor }) => {
+          const storage = this.storage as ChangeReviewStorage;
+          if (options?.resetBaseline || !storage.baseline) {
+            storage.baseline = { snapshot: editor.getJSON(), createdAt: Date.now() };
+          }
+          return true;
+        },
+
+      applyAll:
+        () =>
+        ({ editor }: { editor: TiptapEditor }) => {
+          const storage = this.storage as ChangeReviewStorage;
+          storage.baseline = { snapshot: editor.getJSON(), createdAt: Date.now() };
+          storage.groups = {};
+          // Clear decorations by resetting plugin state
+          const view = editor.view;
+          const pluginState = pluginKey.getState(view.state);
+          if (pluginState) {
+            const empty = DecorationSet.empty;
+            const tr = view.state.tr.setMeta(pluginKey, { resetDecorations: true });
+            view.dispatch(tr);
+            (pluginState as any).decorationSet = empty;
+          }
+          return true;
+        },
+
+      clearReviewState:
+        () =>
+        () => {
+          const storage = this.storage as ChangeReviewStorage;
+          storage.groups = {};
+          return true;
+        },
+
+      applyGroup:
+        (groupId: string) =>
+        ({ editor }: { editor: TiptapEditor }) => {
+          const storage = this.storage as ChangeReviewStorage;
+          if (!storage.groups[groupId]) return false;
+          // Remove decorations for this group by issuing a meta update
+          const view = editor.view;
+          const tr = view.state.tr.setMeta(pluginKey, { removeGroup: groupId });
+          view.dispatch(tr);
+          delete storage.groups[groupId];
+          return true;
+        },
+
+      revertAll:
+        () =>
+        () => {
+          // Placeholder: full inverse application is non-trivial; implement later
+          console.warn("revertAll not implemented yet");
+          return false;
+        },
+
+      revertGroup:
+        (_groupId: string) =>
+        () => {
+          // Placeholder: group inverse; implement later
+          console.warn("revertGroup not implemented yet");
+          return false;
+        },
+
+      toggleGroupVisibility:
+        (groupId: string, visible?: boolean) =>
+        () => {
+          const storage = this.storage as ChangeReviewStorage;
+          const group = storage.groups[groupId];
+          if (!group) return false;
+          group.visible = visible ?? !group.visible;
+          return true;
+        },
+
+      setChangeReviewGroup:
+        (args: { id: string; label?: string; source?: "tool" | "user" } | null) =>
+        () => {
+          const storage = this.storage as ChangeReviewStorage;
+          if (args === null) {
+            storage.activeGroupId = null;
+            return true;
+          }
+          const { id, label, source } = args;
+          storage.activeGroupId = id;
+          getOrCreateGroup(storage, id, label, source ?? "tool");
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const storage = this.storage as ChangeReviewStorage;
+    return [
+      new Plugin({
+        key: pluginKey,
+        state: {
+          init: (_config: unknown, state: EditorState) => {
+            return {
+              decorationSet: DecorationSet.create(state.doc, []),
+              storage,
+            };
+          },
+          apply: (
+            tr: Transaction,
+            pluginState: { decorationSet: DecorationSet; storage: ChangeReviewStorage },
+            oldState: EditorState,
+            newState: EditorState,
+          ) => {
+            let decorationSet = pluginState.decorationSet.map(tr.mapping, tr.doc);
+
+            // Clear all decorations if requested
+            const meta = tr.getMeta(pluginKey) as any;
+            if (meta?.resetDecorations) {
+              decorationSet = DecorationSet.empty;
+            }
+            if (meta?.removeGroup) {
+              // Filter out decorations tagged with this group
+              const groupId = meta.removeGroup as string;
+              const decorations: Decoration[] = [];
+              decorationSet.find().forEach((d: Decoration) => {
+                if ((d.spec as any)?.groupId !== groupId) decorations.push(d);
+              });
+              decorationSet = DecorationSet.create(tr.doc, decorations);
+            }
+
+            // Establish baseline lazily on first doc change
+            if (!storage.baseline && tr.docChanged && storage.mode === "alwaysDiff") {
+              storage.baseline = { snapshot: oldState.doc.toJSON(), createdAt: Date.now() };
+            }
+
+            // Only track diffs when enabled and doc changed
+            if (storage.mode === "alwaysDiff" && tr.docChanged) {
+              const prevDoc = oldState.doc.toJSON();
+              const nextDoc = newState.doc.toJSON();
+              const diff = createJsonDiff(prevDoc, nextDoc);
+
+              const ranges = collectInsertedRanges(tr);
+
+              // Render simple inline decorations for inserted ranges
+              const decos: Decoration[] = [];
+              const groupId = storage.activeGroupId ?? `user:${Date.now()}`;
+              getOrCreateGroup(storage, groupId, storage.activeGroupId ? storage.groups[groupId]?.label : "User Edit", storage.activeGroupId ? storage.groups[groupId]?.source : "user");
+
+              for (const r of ranges) {
+                if (r.to > r.from) {
+                  decos.push(
+                    Decoration.inline(r.from, r.to, {
+                      class: "cr-inserted",
+                      groupId,
+                    })
+                  );
+                }
+              }
+
+              if (decos.length > 0) {
+                decorationSet = decorationSet.add(tr.doc, decos);
+              }
+
+              // Save patch metadata to the group
+              const group = storage.groups[groupId];
+              group.patches.push({
+                prevDocHash: undefined,
+                nextDocHash: undefined,
+                diff,
+                ranges,
+                transactionId: String((tr as any).curId ?? Date.now()),
+              });
+            }
+
+            return {
+              decorationSet,
+              storage,
+            };
+          },
+        },
+        props: {
+          decorations: (state: EditorState) => {
+            const ps = pluginKey.getState(state);
+            return ps?.decorationSet ?? null;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    changeReview: {
+      startReview: (options?: { resetBaseline?: boolean }) => ReturnType;
+      applyAll: () => ReturnType;
+      clearReviewState: () => ReturnType;
+      applyGroup: (groupId: string) => ReturnType;
+      revertAll: () => ReturnType;
+      revertGroup: (groupId: string) => ReturnType;
+      toggleGroupVisibility: (groupId: string, visible?: boolean) => ReturnType;
+      setChangeReviewGroup: (args: { id: string; label?: string; source?: "tool" | "user" } | null) => ReturnType;
+    };
+  }
+}
+

--- a/apps/application/src/components/Editor/tiptap-editor.tsx
+++ b/apps/application/src/components/Editor/tiptap-editor.tsx
@@ -29,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { api } from "../../../convex/_generated/api";
 import { useEscrito } from "@/context/EscritoContext";
+import { ChangeReviewExtension } from "./extensions/changeReview";
 
 interface TiptapProps {
   documentId?: string;
@@ -76,6 +77,24 @@ function MenuBar({ editor }: { editor: Editor }) {
   return (
     <div className="border-b border-gray-200 bg-gray-50/50 px-4 py-3 ">
       <div className="flex items-center gap-1 flex-wrap">
+        {/* Change Review Controls */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => editor.commands.startReview({ resetBaseline: true })}
+          className="h-8 px-2 hover:bg-gray-100 text-xs"
+        >
+          Start Review
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => editor.commands.applyAll()}
+          className="h-8 px-2 hover:bg-gray-100 text-xs"
+        >
+          Apply All
+        </Button>
+
         {/* Undo/Redo */}
         {/* <Button
           variant="ghost"
@@ -286,7 +305,7 @@ export function Tiptap({
   readOnly = false,
 }: TiptapProps) {
   const sync = useTiptapSync(api.prosemirror, documentId);
-  const { setCursorPosition, setTextAroundCursor, setEscritoId } = useEscrito();
+  const { setCursorPosition, setTextAroundCursor, setEscritoId, setEditor } = useEscrito();
 
   // Always call useEditor hook - don't make it conditional
   const editor = useEditor(
@@ -300,6 +319,7 @@ export function Tiptap({
         BlockChange,
         LineBreakChange,
         TrackingExtension,
+        ChangeReviewExtension.configure({ reviewOptions: { mode: "alwaysDiff" } }),
         TextAlign.configure({
           types: ["heading", "paragraph"],
         }),
@@ -374,8 +394,11 @@ export function Tiptap({
 
       // Initial cursor context update
       updateCursorContext(editor);
+
+      // Expose editor in context
+      setEditor(editor);
     }
-  }, [editor, onReady, documentId, setEscritoId]);
+  }, [editor, onReady, documentId, setEscritoId, setEditor]);
 
   useEffect(() => {
     return () => {
@@ -383,8 +406,10 @@ export function Tiptap({
         console.log("TipTap component unmounting");
         onDestroy();
       }
+      // Clear editor from context on unmount
+      setEditor(null);
     };
-  }, [onDestroy]);
+  }, [onDestroy, setEditor]);
 
   // Ensure all hooks are called before any conditional returns
   useEffect(() => {

--- a/apps/application/src/context/EscritoContext.tsx
+++ b/apps/application/src/context/EscritoContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, ReactNode, useState } from "react";
+import type { Editor } from "@tiptap/core";
 
 interface CursorPosition {
   line: number;
@@ -18,6 +19,8 @@ interface EscritoContextType {
   setCursorPosition: (position: CursorPosition | undefined) => void;
   textAroundCursor: TextAroundCursor | undefined;
   setTextAroundCursor: (text: TextAroundCursor | undefined) => void;
+  editor: Editor | null;
+  setEditor: (editor: Editor | null) => void;
 }
 
 const EscritoContext = createContext<EscritoContextType | undefined>(undefined);
@@ -30,6 +33,7 @@ export const EscritoProvider: React.FC<EscritoProviderProps> = ({ children }) =>
   const [escritoId, setEscritoId] = useState<string | undefined>(undefined);
   const [cursorPosition, setCursorPosition] = useState<CursorPosition | undefined>(undefined);
   const [textAroundCursor, setTextAroundCursor] = useState<TextAroundCursor | undefined>(undefined);
+  const [editor, setEditor] = useState<Editor | null>(null);
 
   const contextValue: EscritoContextType = {
     escritoId,
@@ -38,6 +42,8 @@ export const EscritoProvider: React.FC<EscritoProviderProps> = ({ children }) =>
     setCursorPosition,
     textAroundCursor,
     setTextAroundCursor,
+    editor,
+    setEditor,
   };
 
   return (


### PR DESCRIPTION
Implement the foundational `ChangeReviewExtension` to enable always-on diff review, highlighting inserted content from user and tool edits.

This PR lays the groundwork for continuous diff visibility in the editor. It introduces a TipTap plugin that tracks document changes against a baseline, groups them by origin (user or tool), and visually highlights inserted text, allowing users to see accumulated diffs without interrupting their workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-d425301f-761e-4e1c-97a1-d50e372af600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d425301f-761e-4e1c-97a1-d50e372af600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

