### PR TITLE
Feature/docx to tiptap

### DIFF
--- a/apps/application/src/components/Documents/DocumentViewer.tsx
+++ b/apps/application/src/components/Documents/DocumentViewer.tsx
@@ -81,7 +81,11 @@ export default function DocumentViewer({
 
   if (isPdf(mimeType)) {
     return (
-      <iframe src={url} title={title} className={`w-full ${heightClassName} border-0`} />
+      <iframe
+        src={url}
+        title={title}
+        className={`w-full ${heightClassName} border-0`}
+      />
     );
   }
 
@@ -101,10 +105,13 @@ export default function DocumentViewer({
   if (exceedsComplexLimit) {
     return (
       <div className="flex flex-col items-center justify-center bg-white rounded-lg border border-gray-200 p-6 text-center">
-        <h3 className="text-lg font-semibold text-gray-900 mb-2">Archivo demasiado grande para vista previa</h3>
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">
+          Archivo demasiado grande para vista previa
+        </h3>
         <p className="text-gray-600 mb-4 max-w-md">
-          Los archivos de Word, Excel y PowerPoint mayores a 5MB no pueden visualizarse en el navegador.
-          Puedes descargar el archivo para verlo localmente.
+          Los archivos de Word, Excel y PowerPoint mayores a 5MB no pueden
+          visualizarse en el navegador. Puedes descargar el archivo para verlo
+          localmente.
         </p>
         <a
           href={url}
@@ -119,7 +126,9 @@ export default function DocumentViewer({
   }
 
   return (
-    <div className={`bg-white rounded-lg shadow-sm border border-gray-200 overflow-auto ${heightClassName}`}>
+    <div
+      className={`bg-white rounded-lg shadow-sm border border-gray-200 overflow-auto ${heightClassName}`}
+    >
       <Suspense
         fallback={
           <div className="flex items-center justify-center w-full h-full">
@@ -134,15 +143,9 @@ export default function DocumentViewer({
         {isVideo(mimeType) && <VideoViewer url={url} title={title} />}
         {isAudio(mimeType) && <AudioViewer url={url} title={title} />}
         {isPptx(mimeType) && <PptxViewer url={url} title={title} />}
-        {![
-          isDocx,
-          isXlsx,
-          isCsv,
-          isTxt,
-          isVideo,
-          isAudio,
-          isPptx,
-        ].some((fn) => fn(mimeType)) && (
+        {![isDocx, isXlsx, isCsv, isTxt, isVideo, isAudio, isPptx].some((fn) =>
+          fn(mimeType),
+        ) && (
           <div className="p-6 text-center text-gray-600">
             Vista previa no disponible para este tipo de archivo.
           </div>
@@ -151,5 +154,3 @@ export default function DocumentViewer({
     </div>
   );
 }
-
-

--- a/apps/application/src/components/Editor/tiptap-editor.tsx
+++ b/apps/application/src/components/Editor/tiptap-editor.tsx
@@ -27,111 +27,168 @@ export interface TiptapRef {
   getContent: () => JSONContent | null;
 }
 
-export const Tiptap = forwardRef<TiptapRef, TiptapProps>(({
-  documentId = "default-document",
-  templateId = null,
-  onReady,
-  onDestroy,
-  readOnly = false,
-}, ref) => {
-  const sync = useTiptapSync(api.prosemirror, documentId);
-  const { setEscritoId, setCursorPosition, setTextAroundCursor } = useEscrito();
-  const incrementModeloUsage = useMutation(api.functions.templates.incrementModeloUsage);
-  const [searchParams, setSearchParams] = useSearchParams();
-  
-  // Track if template has been applied to prevent reapplying on reload
-  const templateAppliedRef = useRef(false);
-
-  // Always call useTemplate hook to maintain hook order (passes null to skip when no template)
-  const initialContent = useTemplate({ templateId });
-
-  const editor = useEditor(
+export const Tiptap = forwardRef<TiptapRef, TiptapProps>(
+  (
     {
-      extensions: [...extensions, ...(sync.extension ? [sync.extension] : [])],
-      content: sync.initialContent,
-      editable: !readOnly,
-      editorProps: {
-        attributes: {
-          class: `legal-editor-content prose prose-lg focus:outline-none px-12 py-8 min-h-screen ${
-            readOnly ? "cursor-default select-text" : ""
-          }`,
-          "data-placeholder": readOnly
-            ? ""
-            : "Comience a escribir su documento legal...",
-        },
-      },
-      onUpdate: ({ editor }) =>
-        updateCursorContext(editor, setCursorPosition, setTextAroundCursor),
-      onSelectionUpdate: ({ editor }) =>
-        updateCursorContext(editor, setCursorPosition, setTextAroundCursor),
+      documentId = "default-document",
+      templateId = null,
+      onReady,
+      onDestroy,
+      readOnly = false,
     },
-    [sync.initialContent, sync.extension, setCursorPosition, setTextAroundCursor],
-  );
+    ref,
+  ) => {
+    const sync = useTiptapSync(api.prosemirror, documentId);
+    const { setEscritoId, setCursorPosition, setTextAroundCursor } =
+      useEscrito();
+    const incrementModeloUsage = useMutation(
+      api.functions.templates.incrementModeloUsage,
+    );
+    const [searchParams, setSearchParams] = useSearchParams();
 
-  useEffect(() => {
-    if (editor && onReady) {
-      onReady(editor);
-      setEscritoId(documentId);
-      updateCursorContext(editor, setCursorPosition, setTextAroundCursor);
-    }
-  }, [editor, setCursorPosition, setTextAroundCursor]);
+    // Track if template has been applied to prevent reapplying on reload
+    const templateAppliedRef = useRef(false);
 
-  useEffect(() => {
-    return () => onDestroy?.();
-  }, [onDestroy]);
+    // Always call useTemplate hook to maintain hook order (passes null to skip when no template)
+    const initialContent = useTemplate({ templateId });
 
-  useEffect(() => {
-    if (sync.initialContent === null && !sync.isLoading && "create" in sync) {
-      // Only apply template if it hasn't been applied before
-      if (templateId && !templateAppliedRef.current) {
-        sync.create(initialContent as JSONContent);
-        templateAppliedRef.current = true;
-        
-        // Increment template usage counter
-        incrementModeloUsage({ modeloId: templateId });
-        
-        // Remove templateId from URL after applying to prevent reapplication on reload
-        const newSearchParams = new URLSearchParams(searchParams);
-        newSearchParams.delete("templateId");
-        setSearchParams(newSearchParams, { replace: true });
-      } else if (!templateId) {
-        // No template, just create empty document
-        sync.create(initialContent as JSONContent);
+    const editor = useEditor(
+      {
+        extensions: [
+          ...extensions,
+          ...(sync.extension ? [sync.extension] : []),
+        ],
+        content: sync.initialContent,
+        editable: !readOnly,
+        editorProps: {
+          attributes: {
+            class: `legal-editor-content prose prose-lg focus:outline-none px-12 py-8 min-h-screen ${
+              readOnly ? "cursor-default select-text" : ""
+            }`,
+            "data-placeholder": readOnly
+              ? ""
+              : "Comience a escribir su documento legal...",
+          },
+        },
+        onUpdate: ({ editor }) =>
+          updateCursorContext(editor, setCursorPosition, setTextAroundCursor),
+        onSelectionUpdate: ({ editor }) =>
+          updateCursorContext(editor, setCursorPosition, setTextAroundCursor),
+      },
+      [
+        sync.initialContent,
+        sync.extension,
+        setCursorPosition,
+        setTextAroundCursor,
+      ],
+    );
+
+    useEffect(() => {
+      if (editor && onReady) {
+        onReady(editor);
+        setEscritoId(documentId);
+        updateCursorContext(editor, setCursorPosition, setTextAroundCursor);
       }
-    }
-  }, [sync, templateId, initialContent, searchParams, setSearchParams, incrementModeloUsage]);
+    }, [editor, setCursorPosition, setTextAroundCursor]);
 
-  useEffect(() => {
-    if (editor) editor.setEditable(!readOnly);
-  }, [editor, readOnly]);
+    useEffect(() => {
+      return () => onDestroy?.();
+    }, [onDestroy]);
 
-  console.log("editor", editor?.getJSON());
+    useEffect(() => {
+      if (sync.initialContent === null && !sync.isLoading && "create" in sync) {
+        // Check for initial content from DOCX conversion first
+        const storedData = sessionStorage.getItem(
+          `escrito-initial-${documentId}`,
+        );
 
-  useImperativeHandle(ref, () => ({
-    getContent: () => editor?.getJSON() ?? null,
-  }));
+        if (storedData && !templateAppliedRef.current) {
+          try {
+            const {
+              initialContent: docxContent,
+              fromDocxConversion,
+              conversionMetadata,
+            } = JSON.parse(storedData);
 
-  if (sync.isLoading)
-    return <EscritosLoadingState />
-  if (!editor)
-    return <EscritosLoadingState />
+            if (fromDocxConversion && docxContent) {
+              console.log(
+                "Aplicando contenido inicial desde conversión DOCX:",
+                conversionMetadata,
+              );
+              sync.create(docxContent as JSONContent);
+              templateAppliedRef.current = true;
 
-  return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-      {!readOnly && <RibbonBar editor={editor} />}
+              // Clean up stored data after using it
+              sessionStorage.removeItem(`escrito-initial-${documentId}`);
 
-      {readOnly && (
-        <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-amber-800 text-sm">
-          Modo de solo lectura - No tienes permisos para editar este escrito
+              // Show success message with conversion details
+              console.log("✅ Contenido DOCX aplicado exitosamente");
+              return;
+            }
+          } catch (error) {
+            console.error("Error parsing stored DOCX content:", error);
+            // Continue with normal flow if stored data is corrupted
+          }
+        }
+
+        // Normal template/empty document flow
+        if (templateId && !templateAppliedRef.current) {
+          sync.create(initialContent as JSONContent);
+          templateAppliedRef.current = true;
+
+          // Increment template usage counter
+          incrementModeloUsage({ modeloId: templateId });
+
+          // Remove templateId from URL after applying to prevent reapplication on reload
+          const newSearchParams = new URLSearchParams(searchParams);
+          newSearchParams.delete("templateId");
+          setSearchParams(newSearchParams, { replace: true });
+        } else if (!templateId && !templateAppliedRef.current) {
+          // No template, just create empty document
+          sync.create(initialContent as JSONContent);
+          templateAppliedRef.current = true;
+        }
+      }
+    }, [
+      sync,
+      templateId,
+      initialContent,
+      searchParams,
+      setSearchParams,
+      incrementModeloUsage,
+      documentId,
+    ]);
+
+    useEffect(() => {
+      if (editor) editor.setEditable(!readOnly);
+    }, [editor, readOnly]);
+
+    console.log("editor", editor?.getJSON());
+
+    useImperativeHandle(ref, () => ({
+      getContent: () => editor?.getJSON() ?? null,
+    }));
+
+    if (sync.isLoading) return <EscritosLoadingState />;
+    if (!editor) return <EscritosLoadingState />;
+
+    return (
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        {!readOnly && <RibbonBar editor={editor} />}
+
+        {readOnly && (
+          <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-amber-800 text-sm">
+            Modo de solo lectura - No tienes permisos para editar este escrito
+          </div>
+        )}
+
+        <EditorContent editor={editor} className="w-full min-h-[600px]" />
+
+        <div className="border-t border-gray-200 bg-gray-50/50 px-4 py-2 text-xs text-gray-500">
+          Words: {editor.storage.characterCount?.words() ?? 0} | Characters:{" "}
+          {editor.storage.characterCount?.characters() ?? 0}
         </div>
-      )}
-
-      <EditorContent editor={editor} className="w-full min-h-[600px]" />
-
-      <div className="border-t border-gray-200 bg-gray-50/50 px-4 py-2 text-xs text-gray-500">
-        Words: {editor.storage.characterCount?.words() ?? 0} | Characters:{" "}
-        {editor.storage.characterCount?.characters() ?? 0}
       </div>
-    </div>
-  );
-})
+    );
+  },
+);

--- a/apps/application/src/hooks/useDocxToHtml.ts
+++ b/apps/application/src/hooks/useDocxToHtml.ts
@@ -1,0 +1,322 @@
+import { useState, useCallback } from "react";
+
+/**
+ * Configuration options for DOCX to HTML conversion
+ */
+export interface DocxToHtmlOptions {
+  /** Whether to preserve original styling */
+  preserveFormatting?: boolean;
+  /** Whether to include images as base64 data URLs */
+  includeImages?: boolean;
+  /** Whether to convert tables to HTML tables */
+  convertTables?: boolean;
+  /** Custom style mapping for better TipTap compatibility */
+  useCustomStyleMapping?: boolean;
+}
+
+/**
+ * Result of DOCX to HTML conversion
+ */
+export interface DocxToHtmlResult {
+  /** Generated HTML content */
+  html: string;
+  /** Extracted raw text (fallback) */
+  text: string;
+  /** Any warnings or messages from conversion */
+  messages: string[];
+  /** Whether conversion was successful */
+  success: boolean;
+  /** Error message if conversion failed */
+  error?: string;
+  /** Analysis of the document structure */
+  analysis?: {
+    hasImages: boolean;
+    hasTables: boolean;
+    hasHeadings: boolean;
+    paragraphCount: number;
+    estimatedComplexity: "low" | "medium" | "high";
+  };
+}
+
+/**
+ * Hook for converting DOCX files to HTML optimized for TipTap editor
+ */
+export function useDocxToHtml() {
+  const [isConverting, setIsConverting] = useState(false);
+  const [lastResult, setLastResult] = useState<DocxToHtmlResult | null>(null);
+
+  /**
+   * Style mapping optimized for TipTap editor
+   */
+  const getTipTapStyleMapping = useCallback(() => {
+    return {
+      // Convert DOCX paragraph styles to semantic HTML
+      paragraphStyleMap: [
+        // Legal document headings
+        "p[style-name='Heading 1'] => h1:fresh",
+        "p[style-name='Heading 2'] => h2:fresh",
+        "p[style-name='Heading 3'] => h3:fresh",
+        "p[style-name='Heading 4'] => h4:fresh",
+        "p[style-name='Heading 5'] => h5:fresh",
+        "p[style-name='Heading 6'] => h6:fresh",
+
+        // Common legal document styles
+        "p[style-name='Title'] => h1.document-title:fresh",
+        "p[style-name='Subtitle'] => h2.document-subtitle:fresh",
+        "p[style-name='Quote'] => blockquote:fresh",
+        "p[style-name='Intense Quote'] => blockquote.intense:fresh",
+
+        // Lists - TipTap handles these well
+        "p[style-name='List Paragraph'] => p",
+
+        // Default paragraph with proper spacing
+        "p => p:fresh",
+      ],
+    };
+  }, []);
+
+  /**
+   * Clean HTML to ensure TipTap compatibility
+   */
+  const cleanHtmlForTipTap = useCallback((html: string): string => {
+    return (
+      html
+        // Remove XML namespaces and Office-specific attributes
+        .replace(/\s*xmlns[^=]*="[^"]*"/g, "")
+        .replace(/\s*xml:[^=]*="[^"]*"/g, "")
+        .replace(/\s*o:[^=]*="[^"]*"/g, "")
+        .replace(/\s*w:[^=]*="[^"]*"/g, "")
+
+        // Remove empty paragraphs and excessive whitespace
+        .replace(/<p[^>]*>\s*<\/p>/g, "")
+        .replace(/<p[^>]*>(\s|&nbsp;)*<\/p>/g, "")
+
+        // Clean up spacing
+        .replace(/\n\s*\n/g, "\n")
+        .replace(/>\s+</g, "><")
+
+        // Remove unsupported inline styles that might conflict with TipTap
+        .replace(/style="[^"]*"/g, "")
+
+        // Clean up any remaining whitespace
+        .trim()
+    );
+  }, []);
+
+  /**
+   * Analyze DOCX structure to provide insights
+   */
+  const analyzeHtmlStructure = useCallback((html: string, text: string) => {
+    const hasImages = html.includes("<img");
+    const hasTables = html.includes("<table");
+    const hasHeadings = /h[1-6]/i.test(html);
+    const paragraphCount = text
+      .split("\n")
+      .filter((line) => line.trim()).length;
+
+    let estimatedComplexity: "low" | "medium" | "high" = "low";
+    if (hasImages || hasTables || paragraphCount > 100) {
+      estimatedComplexity = "high";
+    } else if (hasHeadings || paragraphCount > 20) {
+      estimatedComplexity = "medium";
+    }
+
+    return {
+      hasImages,
+      hasTables,
+      hasHeadings,
+      paragraphCount,
+      estimatedComplexity,
+    };
+  }, []);
+
+  /**
+   * Convert DOCX file to HTML optimized for TipTap
+   */
+  const convertDocxToHtml = useCallback(
+    async (
+      file: File | ArrayBuffer,
+      options: DocxToHtmlOptions = {},
+    ): Promise<DocxToHtmlResult> => {
+      const { includeImages = false, useCustomStyleMapping = true } = options;
+
+      setIsConverting(true);
+
+      try {
+        console.log("Starting DOCX to HTML conversion", {
+          fileSize: file instanceof File ? file.size : file.byteLength,
+          options,
+        });
+
+        // Convert File to ArrayBuffer if needed
+        let arrayBuffer: ArrayBuffer;
+        if (file instanceof File) {
+          arrayBuffer = await file.arrayBuffer();
+        } else {
+          arrayBuffer = file;
+        }
+
+        // Import mammoth dynamically to avoid TypeScript issues
+        const mammothMod = await import("mammoth");
+        const mammothAny = mammothMod as any;
+
+        // Configure mammoth options for TipTap compatibility
+        const mammothOptions: any = {
+          // Custom style mapping for better TipTap integration
+          ...(useCustomStyleMapping && getTipTapStyleMapping()),
+
+          // Image handling
+          convertImage: includeImages
+            ? mammothAny.images.inline(async (element: any) => {
+                try {
+                  const imageBuffer = await element.read("base64");
+                  return {
+                    src: `data:${element.contentType};base64,${imageBuffer}`,
+                  };
+                } catch (error) {
+                  console.warn("Failed to process image in DOCX", error);
+                  return { src: "" }; // Return empty src to avoid broken images
+                }
+              })
+            : mammothAny.images.ignore,
+        };
+
+        // Perform the conversion
+        const [htmlResult, textResult] = await Promise.all([
+          mammothAny.convertToHtml({ arrayBuffer }, mammothOptions),
+          mammothAny.extractRawText({ arrayBuffer }),
+        ]);
+
+        if (!htmlResult.value) {
+          throw new Error("Mammoth returned empty HTML content");
+        }
+
+        // Clean HTML for TipTap compatibility
+        const cleanedHtml = cleanHtmlForTipTap(htmlResult.value);
+
+        // Analyze the document structure
+        const analysis = analyzeHtmlStructure(cleanedHtml, textResult.value);
+
+        console.log("DOCX to HTML conversion completed successfully", {
+          htmlLength: cleanedHtml.length,
+          textLength: textResult.value.length,
+          messagesCount: htmlResult.messages.length,
+          analysis,
+        });
+
+        // Log any conversion messages/warnings
+        if (htmlResult.messages.length > 0) {
+          console.warn("DOCX conversion messages", htmlResult.messages);
+        }
+
+        const result: DocxToHtmlResult = {
+          html: cleanedHtml,
+          text: textResult.value,
+          messages: htmlResult.messages.map((msg: any) => msg.message),
+          success: true,
+          analysis,
+        };
+
+        setLastResult(result);
+        return result;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        console.error("Failed to convert DOCX to HTML", error);
+
+        // Try to extract at least the text as fallback
+        try {
+          const arrayBuffer =
+            file instanceof File ? await file.arrayBuffer() : file;
+          const mammothMod = await import("mammoth");
+          const mammothAny = mammothMod as any;
+          const textResult = await mammothAny.extractRawText({ arrayBuffer });
+
+          const fallbackResult: DocxToHtmlResult = {
+            html: `<p>${textResult.value.replace(/\n\n/g, "</p><p>").replace(/\n/g, "<br>")}</p>`,
+            text: textResult.value,
+            messages: [],
+            success: false,
+            error: errorMessage,
+          };
+
+          setLastResult(fallbackResult);
+          return fallbackResult;
+        } catch (textError) {
+          const failureResult: DocxToHtmlResult = {
+            html: "",
+            text: "",
+            messages: [],
+            success: false,
+            error: `Complete conversion failure: ${errorMessage}`,
+          };
+
+          setLastResult(failureResult);
+          return failureResult;
+        }
+      } finally {
+        setIsConverting(false);
+      }
+    },
+    [getTipTapStyleMapping, cleanHtmlForTipTap, analyzeHtmlStructure],
+  );
+
+  /**
+   * Validate that the generated HTML is suitable for TipTap
+   */
+  const validateHtmlForTipTap = useCallback(
+    (
+      html: string,
+    ): {
+      isValid: boolean;
+      issues: string[];
+      suggestions: string[];
+    } => {
+      const issues: string[] = [];
+      const suggestions: string[] = [];
+
+      // Check for common TipTap incompatibilities
+      if (html.includes("<table")) {
+        issues.push("Contains tables - TipTap table extension may be needed");
+        suggestions.push(
+          "Consider enabling TipTap Table extension or converting tables to lists",
+        );
+      }
+
+      if (html.includes("<img")) {
+        issues.push("Contains images");
+        suggestions.push("Ensure images are properly sized and accessible");
+      }
+
+      if (html.includes("style=")) {
+        issues.push("Contains inline styles");
+        suggestions.push(
+          "TipTap prefers class-based styling - consider cleaning inline styles",
+        );
+      }
+
+      // Check for empty content
+      const textContent = html.replace(/<[^>]*>/g, "").trim();
+      if (!textContent) {
+        issues.push("No readable text content found");
+        suggestions.push(
+          "Verify the DOCX file contains actual content and not just formatting",
+        );
+      }
+
+      return {
+        isValid: issues.length === 0,
+        issues,
+        suggestions,
+      };
+    },
+    [],
+  );
+
+  return {
+    convertDocxToHtml,
+    validateHtmlForTipTap,
+    isConverting,
+    lastResult,
+  };
+}


### PR DESCRIPTION
# Feature: DOCX to TipTap Editor Conversion

##  Summary
Implement client-side conversion of DOCX documents to editable TipTap escritos, allowing users to convert legal documents into collaborative editors with change tracking.

##  Changes Made

### New Files
- **`src/hooks/useDocxToHtml.ts`** - Custom hook for DOCX → HTML conversion using Mammoth.js
  - Handles DOCX parsing with legal document style mapping
  - Provides document structure analysis and TipTap compatibility validation
  - Includes proper error handling and fallback mechanisms

### Modified Files
- **`src/pages/CaseOpen/CaseDocumentPage.tsx`**
  - Added "Crear Escrito" button for DOCX documents
  - Implemented complete DOCX → TipTap conversion flow
  - Added toast notifications and error handling
  - Integrated with existing permission system

- **`src/components/Editor/tiptap-editor.tsx`**
  - Enhanced initialization to support DOCX-converted content
  - Added sessionStorage-based content loading for converted documents
  - Maintained backward compatibility with templates and empty documents

## How It Works

1. **User clicks "Crear Escrito"** on any DOCX document
2. **Client-side conversion pipeline:**
   - Downloads DOCX from signed URL
   - Converts DOCX → HTML using Mammoth.js
   - Converts HTML → TipTap JSON using `generateJSON()`
   - Creates escrito record in database
3. **Automatic navigation** to TipTap editor with converted content
4. **Change tracking** enabled automatically for all modifications

##  Features
- **100% Client-side** - No backend processing required
- **Legal document optimized** - Custom style mappings for legal formats
- **Error resilient** - Comprehensive error handling with user feedback
- **Permission integrated** - Respects existing case permission system
- **Performance optimized** - Uses sessionStorage for efficient data transfer
